### PR TITLE
Pin build-essential to fix compability with Chef11

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,6 +6,7 @@ cookbook 'apt'
 cookbook 'nginx', git: 'git@github.com:evilmartians/chef-nginx.git', tag: 'v2.2.4'
 cookbook 'php-fpm'
 cookbook 'postgresql_lwrp'
+cookbook 'build-essential', '<4.0.0'
 
 group :integration do
   cookbook 'locale'


### PR DESCRIPTION
related to https://github.com/express42-cookbooks/zabbix_lwrp/issues/10
