### PR TITLE
Rename :modem attribute to :gsm_modem due to zabbixapi uses now

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Installs and configures Zabbix agent and server with PostgreSQL and Nginx. Provi
 - helo:
 - email:
 - path:
-- modem:
+- gsm_modem:
 - username:
 - password:
 
@@ -739,7 +739,7 @@ end
 zabbix_media_type 'sms' do
   action :create
   type :sms
-  modem '/dev/modem'
+  gsm_modem '/dev/modem'
 end
 ```
 

--- a/doc/resources.md
+++ b/doc/resources.md
@@ -405,7 +405,7 @@ end
 zabbix_media_type 'sms' do
   action :create
   type :sms
-  modem '/dev/modem'
+  gsm_modem '/dev/modem'
 end
 ```
 

--- a/providers/media_type.rb
+++ b/providers/media_type.rb
@@ -52,7 +52,7 @@ action :create do
           helo:        new_resource.helo,
           email:       new_resource.email,
           path:        new_resource.path,
-          modem:       new_resource.modem,
+          gsm_modem:   new_resource.gsm_modem,
           username:    new_resource.username,
           password:    new_resource.password,
         },

--- a/resources/media_type.rb
+++ b/resources/media_type.rb
@@ -44,7 +44,7 @@ attribute :email,  kind_of: String
 attribute :path, kind_of: String
 
 # sms
-attribute :modem, kind_of: String
+attribute :gsm_modem, kind_of: String
 
 # jabber
 attribute :username, kind_of: String

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24.rb
@@ -58,7 +58,7 @@ end
 zabbix_media_type 'sms' do
   action :create
   type :sms
-  modem '/dev/modem'
+  gsm_modem '/dev/modem'
 end
 
 zabbix_user_group 'Test group' do

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_without_lvm.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_without_lvm.rb
@@ -55,7 +55,7 @@ end
 zabbix_media_type 'sms' do
   action :create
   type :sms
-  modem '/dev/modem'
+  gsm_modem '/dev/modem'
 end
 
 zabbix_user_group 'Test group' do

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30.rb
@@ -54,7 +54,7 @@ end
 zabbix_media_type 'sms' do
   action :create
   type :sms
-  modem '/dev/modem'
+  gsm_modem '/dev/modem'
 end
 
 zabbix_user_group 'Test group' do

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_without_lvm.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_without_lvm.rb
@@ -53,7 +53,7 @@ end
 zabbix_media_type 'sms' do
   action :create
   type :sms
-  modem '/dev/modem'
+  gsm_modem '/dev/modem'
 end
 
 zabbix_user_group 'Test group' do


### PR DESCRIPTION
Zabbixapi uses a :gsm_modem attribute for a long time. This PR fixes that.
https://github.com/express42/zabbixapi/blob/master/lib/zabbixapi/classes/mediatypes.rb#L28