### PR TITLE
Run state credentials

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -88,6 +88,25 @@ suites:
       attributes:
         db: mysql
 
+  - name: zabbix32-mysql-run-state
+    run_list:
+      - recipe[zabbix_lwrp_test::zabbix32_mysql]
+    excludes:
+      - windows-2012r2
+    verifier:
+      attributes:
+        db: mysql
+    attributes:
+      zabbix:
+        server:
+          credentials:
+            databag: wrapper
+          database:
+            databag: wrapper
+            mysql:
+              databag: wrapper
+
+
   - name: zabbix32-postgresql
     run_list:
       - recipe[zabbix_lwrp_test::zabbix32_postgresql]
@@ -96,3 +115,22 @@ suites:
     verifier:
       attributes:
         db: postgresql
+
+  - name: zabbix32-postgresql-run-state
+    run_list:
+      - recipe[zabbix_lwrp_test::zabbix32_postgresql]
+    excludes:
+      - windows-2012r2
+    verifier:
+      attributes:
+        db: postgresql
+        attributes:
+      zabbix:
+        server:
+          credentials:
+            databag: wrapper
+          database:
+            databag: wrapper
+            postgresql:
+              databag: wrapper
+

--- a/README.md
+++ b/README.md
@@ -390,6 +390,48 @@ Data bag `zabbix` must contains the following items:
 
 For examples see fixture data bag `test/fixtures/databags/zabbix/`
 
+## Using node.run_state
+Optionally this data can be provided in node.run_state instead of data bags.
+
+This is useful in a wrapper cookbook that retrieves credentials from other locations such as chef-vault.
+
+Simply set the 'databag' attributes to the value of the run_state key that contains the data.
+
+### Example Wrapper Cookbook
+```ruby
+  #Your super secret code to get credentials here
+  
+  node.default['zabbix']['server']['database']['databag'] = 'zabbix_data'
+  node.default['zabbix']['server']['database']['postgresql']['databag'] = 'zabbix_data'
+  node.default['zabbix']['server']['credentials']['databag'] = 'zabbix_data'
+
+  node.run_state['zabbix_data'] = {
+    'users' => {
+      'id' => 'users',
+      'users' => {
+        'zabbix' => {
+          'options' => {
+             'password' => secret_zabbix_pass_here
+             'superuser' => false
+           }
+         }
+       }
+    },
+    'databases' => {
+      'id' => 'databases',
+      'databases' => {
+        'zabbix' => { 'options' => { 'owner' => 'zabbix' } }
+      }
+    },
+    'admin' => {'id' => 'admin', 'pass' => secret_admin_pass_here }
+  }
+
+  include_recipe 'zabbix_lwrp::default'
+  include_recipe 'zabbix_lwrp::database'
+  include_recipe 'zabbix_lwrp::server'
+  include_recipe 'zabbix_lwrp::web'
+```
+
 
 # Resources
 

--- a/libraries/load.rb
+++ b/libraries/load.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: zabbix_lwrp
+# Library:: load
+#
+# Author:: Eric Blevins (eblevins@kmilearning.com)
+#
+# Copyright (C) 2017 KMI Learning
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+def get_data_bag(databag)
+  node.run_state[databag] || data_bag(databag)
+end
+
+def get_data_bag_item(databag, item)
+  if node.run_state[databag] && node.run_state[databag][item]
+    node.run_state[databag][item]
+  else
+    data_bag_item(databag, item)
+  end
+end

--- a/providers/connect.rb
+++ b/providers/connect.rb
@@ -37,7 +37,7 @@ action :make do
 
   if credentials_databag
     user = 'Admin'
-    pass = data_bag_item(credentials_databag, 'admin')['pass']
+    pass = get_data_bag_item(credentials_databag, 'admin')['pass']
   end
 
   raise "there aren't user and password for connection to zabbix" if !user || !pass

--- a/providers/database.rb
+++ b/providers/database.rb
@@ -36,7 +36,7 @@ def change_admin_password(db_connect_string)
   admin_user_pass = 'zabbix'
   # Get Admin password from data bag
   begin
-    admin_user_pass = data_bag_item(node['zabbix']['server']['credentials']['databag'], 'admin')['pass']
+    admin_user_pass = get_data_bag_item(node['zabbix']['server']['credentials']['databag'], 'admin')['pass']
   rescue
     log('Using default password for user Admin ... (pass: zabbix)')
   end

--- a/recipes/connect.rb
+++ b/recipes/connect.rb
@@ -34,6 +34,6 @@ include_recipe 'build-essential'
 zabbix_connect 'default' do
   action :make
   apiurl 'http://localhost/api_jsonrpc.php'
-  databag 'zabbix'
+  databag node['zabbix']['server']['credentials']['databag']
   sync node['zabbix']['server']['sync_hosts']
 end

--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -44,16 +44,16 @@ end
 
 if mysql_attr['databag'].nil? ||
    mysql_attr['databag'].empty? ||
-   !data_bag(mysql_attr['databag']).include?('users')
+   !get_data_bag(mysql_attr['databag']).include?('users')
 
   raise "You should specify databag name in node['zabbix']['server']['database']['mysql']['databag'] attibute (now: #{mysql_attr['databag']}) and databag should contains key 'users'"
 end
 
-unless data_bag_item(mysql_attr['databag'], 'users')['users'].key?('root')
+unless get_data_bag_item(mysql_attr['databag'], 'users')['users'].key?('root')
   raise 'You should specify user root in databag users'
 end
 
-unless data_bag_item(mysql_attr['databag'], 'users')['users'].key?('zabbix')
+unless get_data_bag_item(mysql_attr['databag'], 'users')['users'].key?('zabbix')
   raise 'You should specify user zabbix in databag users'
 end
 
@@ -62,7 +62,7 @@ mysql_service mysql_attr['service_name'] do
   port mysql_attr['configuration']['port']
   version mysql_attr['version']
   data_dir mysql_attr['mount_point']
-  initial_root_password data_bag_item(mysql_attr['databag'], 'users')['users']['root']['options']['password']
+  initial_root_password get_data_bag_item(mysql_attr['databag'], 'users')['users']['root']['options']['password']
   action [:create, :start]
 end
 
@@ -70,7 +70,7 @@ end
 db_name = mysql_attr['database_name']
 db_connect_string = "mysql -h #{mysql_attr['configuration']['listen_addresses']} \
                      -P #{mysql_attr['configuration']['port']} -u root \
-                     -p#{data_bag_item(mysql_attr['databag'], 'users')['users']['root']['options']['password']}"
+                     -p#{get_data_bag_item(mysql_attr['databag'], 'users')['users']['root']['options']['password']}"
 
 execute 'Create Zabbix MySQL database' do
   command "#{db_connect_string} -e \"create database if not exists #{db_name} \
@@ -80,7 +80,7 @@ execute 'Create Zabbix MySQL database' do
 end
 
 # create users
-data_bag_item(mysql_attr['databag'], 'users')['users'].each_pair do |name, options|
+get_data_bag_item(mysql_attr['databag'], 'users')['users'].each_pair do |name, options|
   execute "Create MySQL database user #{name}" do
     only_if { name != 'root' }
     command "#{db_connect_string} -e \"grant all privileges on #{db_name}.* to '#{name}'@'%' identified by '#{options['options']['password']}'; \""

--- a/recipes/postgresql.rb
+++ b/recipes/postgresql.rb
@@ -54,7 +54,7 @@ include_recipe 'postgresql::ruby'
 
 if psql_attr['databag'].nil? ||
    psql_attr['databag'].empty? ||
-   !data_bag(psql_attr['databag']).include?('databases')
+   !get_data_bag(psql_attr['databag']).include?('databases')
 
   raise "You should specify databag name in node['zabbix']['server']['database']['databases']['databag'] attibute (now: #{psql_attr['databag']}) and databag should contains key 'databases'"
 end
@@ -74,7 +74,7 @@ postgresql_connection_info = {
   password: node['postgresql']['password']['postgres'],
 }
 
-data_bag_item(psql_attr['databag'], 'users')['users'].each_pair do |name, options|
+get_data_bag_item(psql_attr['databag'], 'users')['users'].each_pair do |name, options|
   postgresql_database_user name do
     connection postgresql_connection_info
     password options['options']['password']
@@ -82,7 +82,7 @@ data_bag_item(psql_attr['databag'], 'users')['users'].each_pair do |name, option
   end
 end
 
-data_bag_item(psql_attr['databag'], 'databases')['databases'].each_pair do |name, options|
+get_data_bag_item(psql_attr['databag'], 'databases')['databases'].each_pair do |name, options|
   postgresql_database name do
     connection postgresql_connection_info
     owner options['options']['owner']

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -41,11 +41,11 @@ db_port = sql_attr['configuration']['port']
 
 if sql_attr['databag'].nil? ||
    sql_attr['databag'].empty? ||
-   data_bag(sql_attr['databag']).empty?
+   get_data_bag(sql_attr['databag']).empty?
   raise "You should specify databag name for zabbix db user in node['zabbix']['server']['database'][db_vendor]['databag'] attibute (now: #{sql_attr['databag']}) and databag should exist"
 end
 
-db_user_data = data_bag_item(sql_attr['databag'], 'users')['users']
+db_user_data = get_data_bag_item(sql_attr['databag'], 'users')['users']
 db_user = db_vendor == 'postgresql' ? db_user_data.keys.first : 'zabbix'
 db_pass = db_user_data[db_user]['options']['password']
 

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -39,11 +39,11 @@ db_port = sql_attr['configuration']['port']
 
 if sql_attr['databag'].nil? ||
    sql_attr['databag'].empty? ||
-   data_bag(sql_attr['databag']).empty?
+   get_data_bag(sql_attr['databag']).empty?
   raise "You should specify databag name for zabbix db user in sql_attr['databag'] attibute (now: #{sql_attr['databag']}) and databag should exist"
 end
 
-db_user_data = data_bag_item(sql_attr['databag'], 'users')['users']
+db_user_data = get_data_bag_item(sql_attr['databag'], 'users')['users']
 db_user = db_user_data.keys.first
 db_pass = db_user_data[db_user]['options']['password']
 

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/run_state.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/run_state.rb
@@ -1,0 +1,19 @@
+#Allow testing credentials in run_state instead of databags
+node.run_state['wrapper'] = {}
+if node['zabbix']['server']['database']['databag'] == 'wrapper'
+  node.run_state['wrapper']['databases'] = data_bag_item('zabbix','databases')
+end
+
+if node['zabbix']['server']['database']['mysql']['databag'] == 'wrapper'
+  node.run_state['wrapper']['users'] = data_bag_item('zabbix','users')
+end
+
+if node['zabbix']['server']['database']['postgresql']['databag'] == 'wrapper'
+  node.run_state['wrapper']['users'] = data_bag_item('zabbix','users')
+end
+
+if node['zabbix']['server']['credentials']['databag'] == 'wrapper'
+  node.run_state['wrapper']['admin'] = data_bag_item('zabbix','admin')
+end
+
+

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/run_state.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/run_state.rb
@@ -1,19 +1,17 @@
-#Allow testing credentials in run_state instead of databags
+# Allow testing credentials in run_state instead of databags
 node.run_state['wrapper'] = {}
 if node['zabbix']['server']['database']['databag'] == 'wrapper'
-  node.run_state['wrapper']['databases'] = data_bag_item('zabbix','databases')
+  node.run_state['wrapper']['databases'] = data_bag_item('zabbix', 'databases')
 end
 
 if node['zabbix']['server']['database']['mysql']['databag'] == 'wrapper'
-  node.run_state['wrapper']['users'] = data_bag_item('zabbix','users')
+  node.run_state['wrapper']['users'] = data_bag_item('zabbix', 'users')
 end
 
 if node['zabbix']['server']['database']['postgresql']['databag'] == 'wrapper'
-  node.run_state['wrapper']['users'] = data_bag_item('zabbix','users')
+  node.run_state['wrapper']['users'] = data_bag_item('zabbix', 'users')
 end
 
 if node['zabbix']['server']['credentials']['databag'] == 'wrapper'
-  node.run_state['wrapper']['admin'] = data_bag_item('zabbix','admin')
+  node.run_state['wrapper']['admin'] = data_bag_item('zabbix', 'admin')
 end
-
-

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_mysql.rb
@@ -175,7 +175,7 @@ include_recipe 'build-essential'
 zabbix_connect 'default' do
   action :nothing
   apiurl 'http://localhost/api_jsonrpc.php'
-  databag 'zabbix'
+  databag node['zabbix']['server']['credentials']['databag']
   sync node['zabbix']['server']['sync_hosts']
 end
 

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_mysql.rb
@@ -43,6 +43,8 @@ when 'rhel'
 end
 include_recipe 'chef_nginx::default'
 
+include_recipe 'zabbix_lwrp_test::run_state'
+
 node.default['zabbix']['version'] = '2.4'
 # Temporary use higher version of zabbixapi, for correct tests works
 # In gem zabbixapi==2.4.X uses old json gem (==1.6.1) but in chefdk uses newest version

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_postgresql.rb
@@ -43,6 +43,8 @@ when 'rhel'
 end
 include_recipe 'chef_nginx::default'
 
+include_recipe 'zabbix_lwrp_test::run_state'
+
 node.default['zabbix']['server']['database']['postgresql']['version'] = '9.6'
 node.default['zabbix']['version'] = '2.4'
 # Temporary use higher version of zabbixapi, for correct tests works

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_postgresql.rb
@@ -170,7 +170,7 @@ include_recipe 'build-essential'
 zabbix_connect 'default' do
   action :nothing
   apiurl 'http://localhost/api_jsonrpc.php'
-  databag 'zabbix'
+  databag node['zabbix']['server']['credentials']['databag']
   sync node['zabbix']['server']['sync_hosts']
 end
 

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_mysql.rb
@@ -172,7 +172,7 @@ include_recipe 'build-essential'
 zabbix_connect 'default' do
   action :nothing
   apiurl 'http://localhost/api_jsonrpc.php'
-  databag 'zabbix'
+  databag node['zabbix']['server']['credentials']['databag']
   sync node['zabbix']['server']['sync_hosts']
 end
 

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_mysql.rb
@@ -43,6 +43,8 @@ when 'rhel'
 end
 include_recipe 'chef_nginx::default'
 
+include_recipe 'zabbix_lwrp_test::run_state'
+
 node.default['zabbix']['version'] = '3.0'
 node.default['zabbix']['api-version'] = '3.0.0'
 node.default['zabbix']['host']['group'] = 'Test group'

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_postgresql.rb
@@ -43,6 +43,8 @@ when 'rhel'
 end
 include_recipe 'chef_nginx::default'
 
+include_recipe 'zabbix_lwrp_test::run_state'
+
 node.default['zabbix']['server']['database']['postgresql']['version'] = '9.6'
 node.default['zabbix']['version'] = '3.0'
 node.default['zabbix']['api-version'] = '3.0.0'

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_postgresql.rb
@@ -168,7 +168,7 @@ include_recipe 'build-essential'
 zabbix_connect 'default' do
   action :nothing
   apiurl 'http://localhost/api_jsonrpc.php'
-  databag 'zabbix'
+  databag node['zabbix']['server']['credentials']['databag']
   sync node['zabbix']['server']['sync_hosts']
 end
 

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_mysql.rb
@@ -172,7 +172,7 @@ include_recipe 'build-essential'
 zabbix_connect 'default' do
   action :nothing
   apiurl 'http://localhost/api_jsonrpc.php'
-  databag 'zabbix'
+  databag node['zabbix']['server']['credentials']['databag']
   sync node['zabbix']['server']['sync_hosts']
 end
 

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_mysql.rb
@@ -43,6 +43,8 @@ when 'rhel'
 end
 include_recipe 'chef_nginx::default'
 
+include_recipe 'zabbix_lwrp_test::run_state'
+
 node.default['zabbix']['version'] = '3.2'
 node.default['zabbix']['api-version'] = '3.1.0'
 node.default['zabbix']['server']['database']['vendor'] = 'mysql'

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_postgresql.rb
@@ -43,6 +43,8 @@ when 'rhel'
 end
 include_recipe 'chef_nginx::default'
 
+include_recipe 'zabbix_lwrp_test::run_state'
+
 node.default['zabbix']['server']['database']['version'] = '9.6'
 node.default['zabbix']['version'] = '3.2'
 node.default['zabbix']['api-version'] = '3.1.0'

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_postgresql.rb
@@ -167,7 +167,7 @@ include_recipe 'build-essential'
 zabbix_connect 'default' do
   action :nothing
   apiurl 'http://localhost/api_jsonrpc.php'
-  databag 'zabbix'
+  databag node['zabbix']['server']['credentials']['databag']
   sync node['zabbix']['server']['sync_hosts']
 end
 


### PR DESCRIPTION
This change optionally allows one to provide the data bag data using node.run_state.
It will enable a wrapper cookbook to provide credentials from locations other than data bags such as chef-vault or encrypted-attributes.

