### PR TITLE
The SenderFrequency parameter was dropped in Zabbix 3.4

### DIFF
--- a/templates/default/zabbix-server.conf.erb
+++ b/templates/default/zabbix-server.conf.erb
@@ -32,8 +32,10 @@ ListenIP=<%= @listenip %>
 <%= parameter %>=<%= value %>
 <% end %>
 
+<% unless node['zabbix']['version'].to_f >= 3.4 %>
 # zabbix sender freq
 SenderFrequency=300
+<% end %>
 
 # Cache params
 


### PR DESCRIPTION
It breaks if you leave this in.