### PR TITLE
Have php_fpm listen on a UNIX socket rather than a TCP port

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ Installs and configures Zabbix agent and server with PostgreSQL/MySQL and Nginx.
 * `node['zabbix']['server']['config']['java_gateway']` -  Defaults to `{ ... }`.
 * `node['zabbix']['server']['config']['alerts']` -  Defaults to `{ ... }`.
 * `node['zabbix']['server']['web']['server_name']` -  Defaults to `localhost`.
-* `node['zabbix']['server']['web']['listen']` -  Defaults to `127.0.0.1`.
-* `node['zabbix']['server']['web']['port']` -  Defaults to `9200`.
+* `node['zabbix']['server']['web']['listen']` -  Defaults to `/var/run/php-fpm-zabbix.sock`.
 * `node['zabbix']['server']['web']['max_requests']` -  Defaults to `500`.
 * `node['zabbix']['server']['web']['max_children']` -  Defaults to `5`.
 * `node['zabbix']['server']['web']['min_spare_servers']` -  Defaults to `1`.

--- a/attributes/web.rb
+++ b/attributes/web.rb
@@ -1,6 +1,5 @@
 default['zabbix']['server']['web']['server_name'] = 'localhost'
-default['zabbix']['server']['web']['listen'] = '127.0.0.1'
-default['zabbix']['server']['web']['port'] = '9200'
+default['zabbix']['server']['web']['listen'] = node['php-fpm']['listen'].gsub(/%{pool_name}/, 'zabbix')
 
 default['zabbix']['server']['web']['max_requests'] = 500
 default['zabbix']['server']['web']['max_children'] = 5

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -47,13 +47,15 @@ db_user_data = get_data_bag_item(sql_attr['databag'], 'users')['users']
 db_user = db_user_data.keys.first
 db_pass = db_user_data[db_user]['options']['password']
 
+fastcgi_listen = node['zabbix']['server']['web']['listen']
+fastcgi_listen = "unix:#{fastcgi_listen}" if fastcgi_listen[0] == '/'
+
 chef_nginx_site node['zabbix']['server']['web']['server_name'] do
   action :enable
   template 'zabbix-site.conf.erb'
   variables(
     server_name: node['zabbix']['server']['web']['server_name'],
-    fastcgi_listen: node['zabbix']['server']['web']['listen'],
-    fastcgi_port: node['zabbix']['server']['web']['port']
+    fastcgi_listen: fastcgi_listen
   )
 end
 
@@ -113,7 +115,8 @@ when 'rhel'
 end
 
 php_fpm_pool 'zabbix' do
-  listen "#{node['zabbix']['server']['web']['listen']}:#{node['zabbix']['server']['web']['port']}"
+  listen_group node['nginx']['group']
+  listen node['zabbix']['server']['web']['listen']
   max_children node['zabbix']['server']['web']['max_children']
   max_requests node['zabbix']['server']['web']['max_requests']
   min_spare_servers node['zabbix']['server']['web']['min_spare_servers']

--- a/templates/default/zabbix-site.conf.erb
+++ b/templates/default/zabbix-site.conf.erb
@@ -18,7 +18,7 @@ server {
 
   location ~* \.php$ {
     fastcgi_index   index.php;
-    fastcgi_pass    <%= @fastcgi_listen %>:<%= @fastcgi_port %>;
+    fastcgi_pass    <%= @fastcgi_listen %>;
     include         fastcgi_params;
     fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
     fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_mysql.rb
@@ -4,11 +4,6 @@ when 'debian'
 when 'rhel'
   include_recipe 'selinux_policy::install'
 
-  # Allow phpfpm to bind to port, by giving it the http_port_t context
-  selinux_policy_port node['zabbix']['server']['web']['port'] do
-    protocol 'tcp'
-    secontext 'http_port_t'
-  end
   selinux_policy_boolean 'httpd_can_network_connect' do
     value true
   end

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix24_postgresql.rb
@@ -4,11 +4,6 @@ when 'debian'
 when 'rhel'
   include_recipe 'selinux_policy::install'
 
-  # Allow phpfpm to bind to port, by giving it the http_port_t context
-  selinux_policy_port node['zabbix']['server']['web']['port'] do
-    protocol 'tcp'
-    secontext 'http_port_t'
-  end
   selinux_policy_boolean 'httpd_can_network_connect' do
     value true
   end

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_mysql.rb
@@ -4,11 +4,6 @@ when 'debian'
 when 'rhel'
   include_recipe 'selinux_policy::install'
 
-  # Allow phpfpm to bind to port, by giving it the http_port_t context
-  selinux_policy_port node['zabbix']['server']['web']['port'] do
-    protocol 'tcp'
-    secontext 'http_port_t'
-  end
   selinux_policy_boolean 'httpd_can_network_connect' do
     value true
   end

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix30_postgresql.rb
@@ -4,11 +4,6 @@ when 'debian'
 when 'rhel'
   include_recipe 'selinux_policy::install'
 
-  # Allow phpfpm to bind to port, by giving it the http_port_t context
-  selinux_policy_port node['zabbix']['server']['web']['port'] do
-    protocol 'tcp'
-    secontext 'http_port_t'
-  end
   selinux_policy_boolean 'httpd_can_network_connect' do
     value true
   end

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_mysql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_mysql.rb
@@ -4,11 +4,6 @@ when 'debian'
 when 'rhel'
   include_recipe 'selinux_policy::install'
 
-  # Allow phpfpm to bind to port, by giving it the http_port_t context
-  selinux_policy_port node['zabbix']['server']['web']['port'] do
-    protocol 'tcp'
-    secontext 'http_port_t'
-  end
   selinux_policy_boolean 'httpd_can_network_connect' do
     value true
   end

--- a/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_postgresql.rb
+++ b/test/fixtures/cookbooks/zabbix_lwrp_test/recipes/zabbix32_postgresql.rb
@@ -4,11 +4,6 @@ when 'debian'
 when 'rhel'
   include_recipe 'selinux_policy::install'
 
-  # Allow phpfpm to bind to port, by giving it the http_port_t context
-  selinux_policy_port node['zabbix']['server']['web']['port'] do
-    protocol 'tcp'
-    secontext 'http_port_t'
-  end
   selinux_policy_boolean 'httpd_can_network_connect' do
     value true
   end

--- a/test/integration/inspec/controls/default.rb
+++ b/test/integration/inspec/controls/default.rb
@@ -130,11 +130,11 @@ end
 
 describe file(php_zabbix_pool_file) do
   it { should be_file }
-  its('content') { should include 'listen = 127.0.0.1:9200' }
+  its('content') { should include 'listen = /var/run/php-fpm-zabbix.sock' }
 end
 
-describe port(9200) do
-  it { should be_listening }
+describe file('/var/run/php-fpm-zabbix.sock') do
+  it { should be_socket }
 end
 
 describe file('/etc/zabbix/web/zabbix.conf.php') do
@@ -152,7 +152,7 @@ describe file('/etc/nginx/sites-available/localhost') do
   it { should be_file }
   its('content') { should include 'listen   80' }
   its('content') { should include 'server_name  localhost' }
-  its('content') { should include 'fastcgi_pass    127.0.0.1:9200' }
+  its('content') { should include 'fastcgi_pass    unix:/var/run/php-fpm-zabbix.sock' }
 end
 
 describe port(80) do


### PR DESCRIPTION
This is faster, more secure, and simplifies SELinux. Note that it is
still possible to listen on a TCP port but now the port has to be
included in the "listen" attribute.