### PR TITLE
Set the nginx listen directive from the proxy_listen attribute

### DIFF
--- a/attributes/web.rb
+++ b/attributes/web.rb
@@ -1,4 +1,5 @@
 default['zabbix']['server']['web']['server_name'] = 'localhost'
+default['zabbix']['server']['web']['proxy_listen'] = '80'
 default['zabbix']['server']['web']['listen'] = '127.0.0.1'
 default['zabbix']['server']['web']['port'] = '9200'
 

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -52,6 +52,7 @@ chef_nginx_site node['zabbix']['server']['web']['server_name'] do
   template 'zabbix-site.conf.erb'
   variables(
     server_name: node['zabbix']['server']['web']['server_name'],
+    proxy_listen: node['zabbix']['server']['web']['proxy_listen'],
     fastcgi_listen: node['zabbix']['server']['web']['listen'],
     fastcgi_port: node['zabbix']['server']['web']['port']
   )

--- a/templates/default/zabbix-site.conf.erb
+++ b/templates/default/zabbix-site.conf.erb
@@ -1,5 +1,5 @@
 server {
-  listen   80;
+  listen <%= @proxy_listen %>;
   server_name  <%= @server_name %>;
   
   root /usr/share/zabbix;

--- a/test/integration/inspec/controls/default.rb
+++ b/test/integration/inspec/controls/default.rb
@@ -150,7 +150,7 @@ end
 
 describe file('/etc/nginx/sites-available/localhost') do
   it { should be_file }
-  its('content') { should include 'listen   80' }
+  its('content') { should include 'listen 80' }
   its('content') { should include 'server_name  localhost' }
   its('content') { should include 'fastcgi_pass    127.0.0.1:9200' }
 end


### PR DESCRIPTION
There are plenty of other directives that could be set from attributes
but listen is one of the few that cannot be set via
node['nginx']['extra_configs'] instead.