### PR TITLE
Server and ServerActive directive should not be populated from one attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Installs and configures Zabbix agent and server with PostgreSQL/MySQL and Nginx.
 * `node['zabbix']['agent']['config']['listen_ip']` -  Defaults to `0.0.0.0`.
 * `node['zabbix']['agent']['config']['listen_port']` -  Defaults to `10050`.
 * `node['zabbix']['agent']['config']['serverhost']` -  Defaults to `localhost`.
+* `node['zabbix']['agent']['config']['serveractive']` -  Defaults to `node['zabbix']['agent']['config']['serverhost']`.
 * `node['zabbix']['agent']['config']['hostname']` -  Defaults to `node['fqdn']`.
 * `node['zabbix']['agent']['config']['pidfile']` -  Defaults to `/var/run/zabbix/zabbix_agentd.pid`.
 * `node['zabbix']['agent']['config']['logs']` -  Defaults to `{ ... }`.

--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -20,6 +20,7 @@ default['zabbix']['agent']['include'] = case node['platform']
 default['zabbix']['agent']['config']['listen_ip'] = '0.0.0.0'
 default['zabbix']['agent']['config']['listen_port'] = 10_050
 default['zabbix']['agent']['config']['serverhost'] = 'localhost'
+default['zabbix']['agent']['config']['serveractive'] = "#{node['zabbix']['agent']['config']['serverhost']}"
 default['zabbix']['agent']['config']['hostname'] = node['fqdn']
 default['zabbix']['agent']['config']['pidfile'] = '/var/run/zabbix/zabbix_agentd.pid'
 

--- a/templates/default/zabbix_agentd.conf.erb
+++ b/templates/default/zabbix_agentd.conf.erb
@@ -17,7 +17,7 @@ PidFile=<%= @pidfile %>
 
 # zabbix server connect configuration
 Server=<%= @serverhost %>
-ServerActive=<%= @serverhost %>
+ServerActive=<%= @serveractive %>
 <% unless @hostname.to_s.empty? %>
 Hostname=<%= @hostname %>
 <% end %>

--- a/test/integration/inspec/controls/default.rb
+++ b/test/integration/inspec/controls/default.rb
@@ -110,6 +110,8 @@ describe file('/etc/zabbix/zabbix_server.conf') do
   its('content') { should include "DBPort=#{db_port}" }
   its('content') { should include 'ListenIP=0.0.0.0' }
   its('content') { should include 'JavaGateway=127.0.0.1' }
+  its('content') { should include 'Server=localhost' }
+  its('content') { should include 'ServerActive=localhost' }
 end
 
 describe port(10_051) do


### PR DESCRIPTION
Server accepts only `ip`, but ServerActive can accept `ip[:port]`

`serverhost` attr now populates only `Server=` directive, for `ServerActive=` use `serveractive` attribute.